### PR TITLE
Strange problem with Rails and fozzie_rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec

--- a/fozzie_rails.gemspec
+++ b/fozzie_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.3"
 
-  gem.add_dependency 'fozzie', '1.0.1'
+  gem.add_dependency 'fozzie', '1.0.2'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.2'

--- a/fozzie_rails.gemspec
+++ b/fozzie_rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'fozzie', '1.0.1'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', '~> 3.2'
   gem.add_development_dependency 'guard'
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'rb-fsevent'

--- a/lib/fozzie/rails/version.rb
+++ b/lib/fozzie/rails/version.rb
@@ -1,5 +1,5 @@
 module Fozzie
   module Rails
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/spec/lib/fozzie/rails/middleware_spec.rb
+++ b/spec/lib/fozzie/rails/middleware_spec.rb
@@ -12,32 +12,32 @@ module Fozzie::Rails
     describe "#rails_version" do
 
       it "returns the major version from Rails.version" do
-        subject.rails_version.should be_kind_of(Integer)
+        expect(subject.rails_version).to be_kind_of(Integer)
       end
     end
 
     describe "#routing_lookup" do
 
       it "returns ::ActionDispatch::Routing::RouteSet instance for Rails 3 and up" do
-        subject.routing_lookup.should be_kind_of(::ActionDispatch::Routing::RouteSet)
+        expect(subject.routing_lookup).to be_kind_of(::ActionDispatch::Routing::RouteSet)
       end
 
       it "returns ActionController::Routing::Routes instance for Rails 2" do
-        ::Rails.should_receive(:version).and_return(2)
-        subject.routing_lookup.should eq ::ActionController::Routing::Routes
+        expect(::Rails).to receive(:version).and_return(2)
+        expect(subject.routing_lookup).to eq ::ActionController::Routing::Routes
       end
     end
   end
 
   describe "#generate_key" do
-    let(:env)     { mock "env" }
-    let(:path)    { mock "path" }
-    let(:routes)  { mock 'routes' }
+    let(:env)     { double "env" }
+    let(:path)    { double "path" }
+    let(:routes)  { double 'routes' }
     subject       { Middleware.new({}) }
 
     it "gets the path_info and request method from env parameter" do
-      env.should_receive(:[]).with("PATH_INFO")
-      env.should_receive(:[]).with("REQUEST_METHOD")
+      expect(env).to receive(:[]).with("PATH_INFO")
+      expect(env).to receive(:[]).with("REQUEST_METHOD")
 
       subject.generate_key(env)
     end
@@ -46,17 +46,17 @@ module Fozzie::Rails
       let(:env) { { "PATH_INFO" => nil } }
 
       it "does not lookup routing" do
-        subject.should_receive(:routing_lookup).never
+        expect(subject).to_not receive(:routing_lookup)
 
         subject.generate_key(env)
       end
 
       it "does not register any stats" do
-        S.should_receive(:increment).never
+        expect(S).to_not receive(:increment)
       end
 
       it "returns nil" do
-        subject.generate_key(env).should be_nil
+        expect(subject.generate_key(env)).to be_nil
       end
     end
 
@@ -64,19 +64,19 @@ module Fozzie::Rails
       let(:env) { { "PATH_INFO" => path, "REQUEST_METHOD" => 'generate_key' } }
 
       before do
-        subject.stub(:routing_lookup => routes)
-        routes.stub(:recognize_path => {:controller => "controller",:action => "action" })
+        allow(subject).to receive(:routing_lookup).and_return(routes)
+        allow(routes).to receive(:recognize_path).and_return({:controller => "controller",:action => "action" })
       end
 
       it "looks up controller and action for the path and request method" do
-        subject.should_receive(:routing_lookup).and_return(routes)
-        routes.should_receive(:recognize_path).with(path, :method => 'generate_key')
+        expect(subject).to receive(:routing_lookup).and_return(routes)
+        expect(routes).to receive(:recognize_path).with(path, :method => 'generate_key')
 
         subject.generate_key(env)
       end
 
       it "returns a bucket generated from the controller, action, and 'render'" do
-        subject.generate_key(env).should eq "controller.action.render"
+        expect(subject.generate_key(env)).to eq "controller.action.render"
       end
     end
   end

--- a/spec/lib/fozzie/rails/railtie_spec.rb
+++ b/spec/lib/fozzie/rails/railtie_spec.rb
@@ -4,7 +4,7 @@ module Fozzie::Rails
   describe Railtie do
 
     it "is loaded when Rails exists" do
-      Application.middleware.middlewares.should include(Fozzie::Rails::Middleware)
+      expect(Application.middleware.middlewares).to include(Fozzie::Rails::Middleware)
     end
   end
 end


### PR DESCRIPTION
Hello,
I am using Rails (4.0.0) and fozzie_rails, I found very strange bug that is gone when I remove fozzie_rails from Gemfile and that error happens **only in development env**.

With fozzie_rails in Gemfile:
```ruby
Loading development environment (Rails 4.1.0.beta)
[1] pry(main)> Management::PdfServiceController
NameError: uninitialized constant Management::PdfServiceController
from (pry):1:in `evaluate_ruby'
```

without fozzie and fozzie_rails:
```ruby
Loading development environment (Rails 4.1.0.beta)
[1] pry(main)> Management::PdfServiceController
=> Management::PdfServiceController
```